### PR TITLE
Custom attribute

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -64,6 +64,12 @@
                         <td>Use this placeholder image. Can be a relative/absolute URL or data-URI. Defaults to a transparent pixel. Can also be set per-image by `data-src-placeholder` attribute.</td>
                     </tr>
                     <tr>
+                        <th scope="row">attribute</th>
+                        <td>string</td>
+                        <td>src</td>
+                        <td>Custom data attribute for image source</td>
+                    </tr>
+                    <tr>
                         <th scope="row">breakpoints</th>
                         <td>array</td>
                         <td>[]</td>

--- a/src/jquery.unveil2.js
+++ b/src/jquery.unveil2.js
@@ -64,6 +64,7 @@
                 breakpoints: [],
                 throttle: 250,
                 debug: false,
+                attribute: srcString,
 
                 // Undocumented
                 container: $window,
@@ -94,7 +95,7 @@
          */
         this.one(unveilString + '.' + unveilString, function () {
             var i, $this = $(this), windowWidth = $window.width(),
-                attrib = srcString, targetSrc, defaultSrc, retinaSrc;
+                attrib = settings.attribute, targetSrc, defaultSrc, retinaSrc;
 
             // Determine attribute to extract source from
             for (i = 0; i < settings.breakpoints.length; i++) {
@@ -279,8 +280,8 @@
                 $this.data(unveilString, true);
 
                 // Set data-src if not set
-                if (!$this.data(srcString)) {
-                    $this.data(srcString, $this.prop(srcString));
+                if (!$this.data(settings.attribute)) {
+                    $this.data(settings.attribute, $this.prop(settings.attribute));
                 }
 
                 // Set placeholder

--- a/test/tests.js
+++ b/test/tests.js
@@ -56,6 +56,25 @@
         });
     });
 
+    QUnit.test("Custom attribute source test", function (assert) {
+        var done = assert.async(1);
+        var image = $('<img/>')
+            .addClass('lazy')
+            .attr('data-custom', uniqueImageUrl())
+            .appendTo('body');
+
+        image.on('loaded.unveil', function () {
+            assert.ok(image.prop('src').indexOf(imageUrl) > -1, 'Image source should now be set');
+            image.remove();
+            done();
+        });
+
+        $(image).unveil({
+            attribute: 'custom',
+            debug: debug
+        });
+    });
+
     QUnit.test("Placeholder test", function (assert) {
         var done = assert.async(1);
         var image = $('<img/>')


### PR DESCRIPTION
Hi! Sometimes in legacy systems we might have a different attribute for source of image like `data-original` or `data-img-source`. For those cases it would be great to have this customisation.