### PR TITLE
Update qunit to 2.0.1, jquery to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "grunt-contrib-qunit": "^1.2.0",
     "grunt-contrib-uglify": "*",
     "grunt-saucelabs": "~4",
-    "grunt-travis-matrix": "^1.0.0"
+    "grunt-travis-matrix": "^1.0.0",
+    "jquery": "^3.1.1",
+    "qunitjs": "^2.0.1"
   },
   "scripts": {
     "test": "grunt test"

--- a/test/tests.html
+++ b/test/tests.html
@@ -3,14 +3,14 @@
 <head>
 	<meta charset="utf-8">
 	<title>QUnit tests</title>
-	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/qunit/1.18.0/qunit.min.css">
+	<link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
 	<link rel="stylesheet" href="style.css">
 </head>
 <body>
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/qunit/1.18.0/qunit.min.js"></script>
+<script src="../node_modules/jquery/dist/jquery.min.js"></script>
+<script src="../node_modules/qunitjs/qunit/qunit.js"></script>
 <script src="../src/jquery.unveil2.js"></script>
 <script src="tests.js"></script>
 </body>


### PR DESCRIPTION
Seems that we can use qunit@2.0.1 without updating grunt-contrib-qunit. At least locally it worked.
@hongaar please review.