### PR TITLE
Don't unveil twice the same image

### DIFF
--- a/src/jquery.unveil2.js
+++ b/src/jquery.unveil2.js
@@ -187,7 +187,7 @@
         });
 
         this.one('destroy' + unveilNamespace, function () {
-            $(this).off(unveilNamespace);
+            $(this).off(unveilNamespace).removeData(unveilString);
             if (containerContext.images) {
                 containerContext.images = containerContext.images.not(this);
                 if (!containerContext.images.length) {
@@ -302,9 +302,8 @@
         }
 
         function destroyContainer() {
-            settings.container.off(unveilNamespace);
-            containerContext.images.off(unveilNamespace);
-            settings.container.data(unveilString, null);
+            settings.container.off(unveilNamespace).removeData(unveilString);
+            containerContext.images.off(unveilNamespace).removeData(unveilString);
             containerContext.initialized = false;
             containerContext.images = null;
         }

--- a/src/jquery.unveil2.js
+++ b/src/jquery.unveil2.js
@@ -321,12 +321,12 @@
             var $this = $(this),
                 elmPlaceholder = $this.data(srcString + '-' + placeholderString) || settings.placeholder;
 
-            // Add element to global array
-            containerContext.images = $(containerContext.images).add(this);
-
             // If this element has been called before,
             // don't set placeholder now to prevent FOUI (Flash Of Ustyled Image)
             if (!$this.data(unveilString)) {
+
+                // Add element to global array
+                containerContext.images = $(containerContext.images).add(this);
 
                 // Set the unveil flag
                 $this.data(unveilString, true);

--- a/test/tests.js
+++ b/test/tests.js
@@ -27,7 +27,7 @@
 
     QUnit.module("Unveil tests", {
         beforeEach: function () {
-            $('body').append('<div id="testContainer"></div>');
+            $('body').prepend('<div id="testContainer"></div>');
         },
         afterEach: function () {
             $('#testContainer').remove();


### PR DESCRIPTION
Hi! In case of multiple calls over the same image, it's processed over the unveil mechanism as many times as multiplicity goes. Lets get rid of this nonsense.

@hongaar please review.